### PR TITLE
Loosening active support requirement

### DIFF
--- a/ruby-stellar-sdk.gemspec
+++ b/ruby-stellar-sdk.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "hyperclient", "~> 0.7"
   spec.add_dependency "excon", "~> 0.44", ">= 0.44.4"
   spec.add_dependency "contracts", "~> 0.16"
-  spec.add_dependency "activesupport", ">= 5.2.0"
+  spec.add_dependency "activesupport", ">= 5.0"
   spec.add_dependency "toml-rb", "~> 1.1", ">= 1.1.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"


### PR DESCRIPTION
Last week, I was not able to add this gem to a Rails 5.1 project due to the `activesupport` requirement. I think requiring `~> 5.0` is safe enough given that only `ActiveSupport::Autoload` is being used.
