### PR TITLE
 Added Ruby 2.6 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-- 2.3.1
 - 2.4.1
 - 2.5.1
+- 2.6.1
 - jruby-9.1.6.0
 cache: bundler
 before_install:


### PR DESCRIPTION
Also, remove 2.3 given that it reached EOL.

It seems that the current setup is failing due to an issue with JRuby.